### PR TITLE
rfs-acl: Added log option to service

### DIFF
--- a/packages/acl-rfs/package-meta-data.xml
+++ b/packages/acl-rfs/package-meta-data.xml
@@ -1,6 +1,6 @@
 <ncs-package xmlns="http://tail-f.com/ns/ncs-packages">
   <name>acl-rfs</name>
-  <package-version>1.0</package-version>
+  <package-version>2.0</package-version>
   <description>Dummy ACL RFS package for demo purposes</description>
   <ncs-min-version>6.0</ncs-min-version>
 

--- a/packages/acl-rfs/src/yang/acl-rfs.yang
+++ b/packages/acl-rfs/src/yang/acl-rfs.yang
@@ -16,6 +16,11 @@ module acl-rfs {
   description
     "Small rfs package for demonstration purposes";
 
+  revision 2026-02-07 {
+    description
+      "Added logging flag to the ACL rule";
+  }
+
   revision 2025-02-02 {
     description
       "Awesome NetDevOps demo";
@@ -68,7 +73,13 @@ module acl-rfs {
           tailf:info "Destination IP address";
           type inet:ipv4-address;
           mandatory true;
-        }        
+        }
+
+        leaf log {
+          tailf:info "Logging option";
+          type boolean;
+          default false;
+        }    
       }
     }
   }


### PR DESCRIPTION
- Indeed, we added a new leaf to the yang for enabling logging of the ACL lines generated by this rfs
- Nothing to fancy, but let's see if it flies
- Cheers!